### PR TITLE
【Fixed】チーム情報の操作に関しての機能を整えた

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -17,7 +17,6 @@ class AssignsController < ApplicationController
   def destroy
     assign = Assign.find(params[:id])
     team = find_team(params[:team_id])
-    binding.irb
      if current_user == team.owner || current_user == assign.user
        destroy_message = assign_destroy(assign, assign.user)
        redirect_to team_url(params[:team_id]), notice: destroy_message

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -16,9 +16,14 @@ class AssignsController < ApplicationController
 
   def destroy
     assign = Assign.find(params[:id])
-    destroy_message = assign_destroy(assign, assign.user)
-
-    redirect_to team_url(params[:team_id]), notice: destroy_message
+    team = find_team(params[:team_id])
+    binding.irb
+     if current_user == team.owner || current_user == assign.user
+       destroy_message = assign_destroy(assign, assign.user)
+       redirect_to team_url(params[:team_id]), notice: destroy_message
+     else
+       redirect_to team_url(params[:team_id]), notice: 'メンバーを削除できません。'
+     end
   end
 
   private

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -21,7 +21,7 @@ class AssignsController < ApplicationController
        destroy_message = assign_destroy(assign, assign.user)
        redirect_to team_url(params[:team_id]), notice: destroy_message
      else
-       redirect_to team_url(params[:team_id]), notice: 'メンバーを削除できません。'
+       redirect_to team_url(params[:team_id]), notice: I18n.t('views.messages.cannot_delete_member')
      end
   end
 

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -30,11 +30,15 @@ class TeamsController < ApplicationController
   end
 
   def update
-    if @team.update(team_params)
-      redirect_to @team, notice: I18n.t('views.messages.update_team')
+    if @team.owner == current_user
+      if @team.update(team_params)
+        redirect_to @team, notice: I18n.t('views.messages.update_team')
+      else
+        flash.now[:error] = I18n.t('views.messages.failed_to_save_team')
+        render :edit
+      end
     else
-      flash.now[:error] = I18n.t('views.messages.failed_to_save_team')
-      render :edit
+      redirect_to @team, notice: I18n.t('views.messages.cannot_update_team_unless_the_leader')
     end
   end
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -220,6 +220,7 @@ ja:
       create_team: 'チーム作成に成功しました！'
       failed_to_save_team: '保存に失敗しました、、'
       update_team: 'チーム更新に成功しました！'
+      cannot_update_team_unless_the_leader: 'リーダーでない限りチームを更新できません、、'
       delete_team: 'チーム削除に成功しました！'
       update_profile: 'プロフィールを編集しました！'
       complete_registration: '登録完了'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -215,6 +215,7 @@ ja:
       cannot_delete_the_leader: 'リーダーは削除できません。'
       cannot_delete_only_a_member: 'このユーザーはこのチームにしか所属していないため、削除できません。'
       delete_member: 'メンバーを削除しました。'
+      cannot_delete_member: 'メンバーを削除できません。'
       cannot_delete_member_4_some_reason: 'なんらかの原因で、削除できませんでした。'
       failed_to_post: '投稿できませんでした...'
       create_team: 'チーム作成に成功しました！'


### PR DESCRIPTION
Feature/issues-#1

・ 修正前：そのTeamに所属しているUserの削除（離脱）が、どのUserでもできる状態
　 **修正後：Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにした**
　 ※ 主にassigns_controller.rb にコードを追記

・ 修正前：TeamのeditをTeamのリーダー（オーナー）以外でも自由にできる状態
　 **修正後：TeamのeditはTeamのリーダー（オーナー）のみができるようにした**
　 ※ 主にteams_controller.rb にコードを追記